### PR TITLE
Small fixes/workarounds in signin functionality

### DIFF
--- a/app/elements/expert-signin/expert-signin.html
+++ b/app/elements/expert-signin/expert-signin.html
@@ -46,7 +46,7 @@
           user: {
             type: Object,
             notify: true,
-            readonly: true,
+            readOnly: true,
             computed: '_computeUser(_googleUser, _apiUser)'
           },
 
@@ -55,7 +55,7 @@
            */
           isAuthorized: {
             type: Boolean,
-            readonly: true,
+            readOnly: true,
             notify: true,
             value: false,
             computed: '_computeAuthorized(user)'
@@ -120,7 +120,7 @@
           this._apiUser = undefined;
           this._localUser = {};
           this._isAuthorized = false;
-          this._setUser({});
+          this.__setProperty('user', {});
         },
 
         /**
@@ -150,6 +150,7 @@
          * Basic user information and access rights for the user
          */
         _computeUser: function (googleUser, apiUser) {
+          console.log(googleUser, apiUser);
           if (!googleUser || !googleUser.id || !apiUser || !apiUser.id) {
             return {};
           }

--- a/app/elements/expert-signin/expert-signin.html
+++ b/app/elements/expert-signin/expert-signin.html
@@ -150,7 +150,6 @@
          * Basic user information and access rights for the user
          */
         _computeUser: function (googleUser, apiUser) {
-          console.log(googleUser, apiUser);
           if (!googleUser || !googleUser.id || !apiUser || !apiUser.id) {
             return {};
           }

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -113,10 +113,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     display: none;
   }
 
-  #mainToolbar.has-shadow gde-signin {
+  #mainToolbar.has-shadow expert-signin {
     display: none;
   }
-  
+
   #mainToolbar.has-shadow .app-name > img {
     width: 20px;
     height: 20px;
@@ -134,17 +134,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     margin-right: 10px;
     border-radius: 50%;
   }
-  
+
   .app-name img {
     width: 48px;
     height: 48px;
   }
-  
+
   span.tag {
     min-width: 150px;
     margin-right: 5px;
   }
-  
+
   span.descr {
     width: 320px;
   }


### PR DESCRIPTION
It seems with Polymer 1.0.6 the private setters (i.e. _setUser) are only generated for "pure" readOnly properties, and not for readOnly properties that are also computed. Since we still have the issue of the user not being re-computed when googleUser/apiUser are set to `undefined` in the signedOut handler, and setting those objects to `null` instead of `undefined` has some other unwanted side-effects, I'm using the Polymer-internal `__setProperty` function now to properly reset the user when signing out.
