### PR TITLE
Set default activityLink

### DIFF
--- a/src/experts-activities/experts-activity-detail-create.html
+++ b/src/experts-activities/experts-activity-detail-create.html
@@ -239,9 +239,10 @@
 
       },
       _isSubmitDisabled: function() {
-        console.log(this.detail.detail_type && this.$.inputUrl.validate() && (this.detail.metric_reached > 0 || this.detail.metric_indirect > 0 || this.detail.metric_trained > 0));
-        console.log(this.detail.detail_type, this.$.inputUrl.validate(), (this.detail.metric_reached > 0 || this.detail.metric_indirect > 0 || this.detail.metric_trained > 0));
-        return (this.detail.detail_type && this.$.inputUrl.validate() && (this.detail.metric_reached > 0 || this.detail.metric_indirect > 0 || this.detail.metric_trained > 0));
+        return this.detail.detail_type && this.$.inputUrl.validate() && this._metricExists();
+      },
+      _metricExists: function() {
+        return [this.detail.metric_reached, this.detail.metric_indirect, this.detail.metric_trained].some(metric => metric > 0);
       },
       _initNewActivityDetailIfNeeded: function() {
         if (!this.detail.url) {
@@ -252,11 +253,10 @@
             this.initial_detail_type = i;
           }
         }
-        console.debug("[experts-activity-detail-create] _initNewActivityDetailIfNeeded ",{ detail: this.detail, initial_detail_type: this.initial_detail_type});
       },
       _initNewActivityDetail: function() {
         this.detail = {
-          'detail_type': '',
+          'detail_type': 'Generic URL',
           'url': '',
           'metric_reached': 0,
           'metric_indirect': 0,
@@ -279,7 +279,6 @@
         if (!this.detail.metric_trained) {
           this.detail.metric_trained = 0;
         }
-        console.debug("[experts-activity-detail-create] _submitActivityDetail ", this.detail);
 
         var request = this.$.insertActivityDetail;
         request.body = JSON.stringify(this.detail);
@@ -303,7 +302,6 @@
         this.close();
       },
       _activityLinkSelected: function(evt, obj) {
-        console.debug("[experts-activity-create] _activityLinkSelected", obj.item.dataLink);
         this._chosenActivityLink = obj.item.dataLink;
         this._activateMetrics = true;
       },


### PR DESCRIPTION
Fixes #130.

`this.detail.detail_type` defaulted to an empty value and `_isSubmitDisabled` would be true until the user selected an detail type.

Also moved some logic into the `_metricExists` method.